### PR TITLE
Update authentication to use updated spdystream interface

### DIFF
--- a/http2/listener.go
+++ b/http2/listener.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/libchan"
 	"github.com/docker/spdystream"
 	"net"
+	"net/http"
 	"sync"
 )
 
@@ -32,6 +33,8 @@ func NewListenSession(listener net.Listener, auth Authenticator) (*ListenSession
 }
 
 func (l *ListenSession) streamHandler(stream *spdystream.Stream) {
+	// TODO authorize stream
+	stream.SendReply(http.Header{}, false)
 	streamChan := l.getStreamChan(stream.Parent())
 	streamChan <- stream
 }
@@ -67,7 +70,7 @@ func (l *ListenSession) Serve() {
 		}
 
 		go func() {
-			authHandler, authErr := l.auth(conn)
+			authErr := l.auth(conn)
 			if authErr != nil {
 				// TODO log
 				conn.Close()
@@ -81,7 +84,7 @@ func (l *ListenSession) Serve() {
 				return
 			}
 
-			go spdyConn.Serve(l.streamHandler, authHandler)
+			go spdyConn.Serve(l.streamHandler)
 		}()
 	}
 }

--- a/http2/listener_test.go
+++ b/http2/listener_test.go
@@ -74,7 +74,7 @@ func exerciseServer(t *testing.T, server string, endChan chan bool) {
 		t.Fatalf("Error sending message: %s", sendErr)
 	}
 
-	msg, receiveErr := receiver.Receive(0) //libchan.Ret
+	msg, receiveErr := receiver.Receive(0)
 	if receiveErr != nil {
 		t.Fatalf("Error receiving message")
 	}

--- a/http2/spdy.go
+++ b/http2/spdy.go
@@ -20,16 +20,14 @@ import (
 // a new connection.  Authenticator allows tls handshakes to
 // occur or any desired authentication of a network connection
 // before passing off the connection to session management.
-type Authenticator func(conn net.Conn) (spdystream.AuthHandler, error)
+type Authenticator func(conn net.Conn) error
 
 // NoAuthenticator is an implementation of authenticator which
 // does no security.  This should only be used for testing or with
 // caution when network connections are already guarenteed to
 // be secure.
-func NoAuthenticator(conn net.Conn) (spdystream.AuthHandler, error) {
-	return func(header http.Header, slot uint8, parent uint32) bool {
-		return true
-	}, nil
+func NoAuthenticator(conn net.Conn) error {
+	return nil
 }
 
 type streamChanProvider interface {

--- a/http2/stream.go
+++ b/http2/stream.go
@@ -37,6 +37,7 @@ func (s *StreamSession) getStreamChan(stream *spdystream.Stream) chan *spdystrea
 }
 
 func (s *StreamSession) newStreamHandler(stream *spdystream.Stream) {
+	stream.SendReply(http.Header{}, false)
 	streamChan := s.getStreamChan(stream.Parent())
 	streamChan <- stream
 }
@@ -54,7 +55,7 @@ func NewStreamSession(conn net.Conn) (*StreamSession, error) {
 	if spdyErr != nil {
 		return nil, spdyErr
 	}
-	go spdyConn.Serve(session.newStreamHandler, spdystream.NoAuthHandler)
+	go spdyConn.Serve(session.newStreamHandler)
 
 	session.conn = spdyConn
 


### PR DESCRIPTION
Update the authentication interface to align with the changes in spdystream.  Authentication of new connections in the listener will still use an Authenticator function, however authorization of individual streams should not be done in the stream handler instead of a separate authorize function returned by the Authenticator function.  This change also requires new stream handlers to now handle sending the reply on the stream.
