### PR TITLE
Update listener to use stream session

### DIFF
--- a/http2/listener.go
+++ b/http2/listener.go
@@ -1,21 +1,14 @@
 package http2
 
 import (
-	"github.com/docker/libchan"
-	"github.com/docker/spdystream"
 	"net"
-	"net/http"
-	"sync"
 )
 
 // ListenSession is a session manager which accepts new
 // connections and spawns spdy connection managers.
 type ListenSession struct {
-	listener       net.Listener
-	streamChan     chan *spdystream.Stream
-	streamLock     sync.RWMutex
-	subStreamChans map[string]chan *spdystream.Stream
-	auth           Authenticator
+	listener net.Listener
+	auth     Authenticator
 }
 
 // NewListenSession creates a new listen session using
@@ -25,68 +18,9 @@ type ListenSession struct {
 // ListenSession will not perform tls handshakes.
 func NewListenSession(listener net.Listener, auth Authenticator) (*ListenSession, error) {
 	return &ListenSession{
-		listener:       listener,
-		streamChan:     make(chan *spdystream.Stream),
-		subStreamChans: make(map[string]chan *spdystream.Stream),
-		auth:           auth,
+		listener: listener,
+		auth:     auth,
 	}, nil
-}
-
-func (l *ListenSession) streamHandler(stream *spdystream.Stream) {
-	// TODO authorize stream
-	stream.SendReply(http.Header{}, false)
-	streamChan := l.getStreamChan(stream.Parent())
-	streamChan <- stream
-}
-
-func (l *ListenSession) addStreamChan(stream *spdystream.Stream, streamChan chan *spdystream.Stream) {
-	l.streamLock.Lock()
-	l.subStreamChans[stream.String()] = streamChan
-	l.streamLock.Unlock()
-}
-
-func (l *ListenSession) getStreamChan(stream *spdystream.Stream) chan *spdystream.Stream {
-	if stream == nil {
-		return l.streamChan
-	}
-	l.streamLock.RLock()
-	defer l.streamLock.RUnlock()
-	streamChan, ok := l.subStreamChans[stream.String()]
-	if ok {
-		return streamChan
-	}
-	return l.streamChan
-}
-
-// Serve runs the listen accept loop, spawning connection manager
-// for each accepted connection. This function will block until
-// the listener is closed or an error occurs on accept.
-func (l *ListenSession) Serve() {
-	for {
-		conn, err := l.listener.Accept()
-		if err != nil {
-			// TODO log
-			break
-		}
-
-		go func() {
-			authErr := l.auth(conn)
-			if authErr != nil {
-				// TODO log
-				conn.Close()
-				return
-			}
-
-			spdyConn, spdyErr := spdystream.NewConnection(conn, true)
-			if spdyErr != nil {
-				// TODO log
-				conn.Close()
-				return
-			}
-
-			go spdyConn.Serve(l.streamHandler)
-		}()
-	}
 }
 
 // Close closes the underlying listener
@@ -94,9 +28,22 @@ func (l *ListenSession) Close() error {
 	return l.listener.Close()
 }
 
-// AcceptReceiver waits for a stream to be created in
-// the session and returns a receiver for that stream.
-func (l *ListenSession) AcceptReceiver() (libchan.Receiver, error) {
-	stream := <-l.streamChan
-	return &StreamReceiver{stream: stream, streamChans: l, ret: &StreamSender{stream: stream, streamChans: l}}, nil
+// AcceptSessions waits for a new network connections
+// and creates a new stream.  Connections which fail
+// authentication will not be returned.
+func (l *ListenSession) AcceptSession() (*StreamSession, error) {
+	for {
+		conn, err := l.listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		authErr := l.auth(conn)
+		if authErr != nil {
+			// TODO log
+			conn.Close()
+			continue
+		}
+
+		return newStreamSession(conn, true)
+	}
 }

--- a/http2/listener_test.go
+++ b/http2/listener_test.go
@@ -14,17 +14,19 @@ func TestListenSession(t *testing.T) {
 		t.Fatalf("Error creating listener: %s", listenErr)
 	}
 
-	session, sessionErr := NewListenSession(listener, NoAuthenticator)
-	if sessionErr != nil {
-		t.Fatalf("Error creating session: %s", sessionErr)
+	listenSession, listenSessionErr := NewListenSession(listener, NoAuthenticator)
+	if listenSessionErr != nil {
+		t.Fatalf("Error creating session: %s", listenSessionErr)
 	}
-
-	go session.Serve()
 
 	end := make(chan bool)
 	go exerciseServer(t, listen, end)
 
-	receiver, receiverErr := session.AcceptReceiver()
+	session, sessionErr := listenSession.AcceptSession()
+	if sessionErr != nil {
+		t.Fatalf("Error accepting session: %s", sessionErr)
+	}
+	receiver, receiverErr := session.ReceiverWait()
 	if receiverErr != nil {
 		t.Fatalf("Error accepting receiver: %s", receiverErr)
 	}

--- a/http2/stream_test.go
+++ b/http2/stream_test.go
@@ -103,17 +103,20 @@ func runServer(listen string, t *testing.T, endChan chan bool) (io.Closer, error
 		return nil, lErr
 	}
 
-	session, sessionErr := NewListenSession(listener, NoAuthenticator)
-	if sessionErr != nil {
-		t.Fatalf("Error creating session: %s", sessionErr)
+	listenSession, listenSessionErr := NewListenSession(listener, NoAuthenticator)
+	if listenSessionErr != nil {
+		t.Fatalf("Error creating session listener: %s", listenSessionErr)
 	}
-
-	go session.Serve()
 
 	go func() {
 		defer close(endChan)
 
-		receiver, receiverErr := session.AcceptReceiver()
+		session, sessionErr := listenSession.AcceptSession()
+		if sessionErr != nil {
+			t.Fatalf("Error accepting session: %s", sessionErr)
+		}
+
+		receiver, receiverErr := session.ReceiverWait()
 		if receiverErr != nil {
 			t.Fatalf("Error accepting receiver: %s", receiverErr)
 		}


### PR DESCRIPTION
Listener is currently broken when multiple connections are created, using sessions allows proper separation of each connection.
A sync condition is added around stream chans to avoid race conditions between setting stream chans and reading them.  The original behavior used the global stream chan when the stream was not found, however that led to synchronization issues when sender/receivers sometimes got back different channels.
