### PR TITLE
Fix references to dotcloud repo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ the same rules and principles. If you're already familiar with the way
 Docker does things, you'll feel right at home.
 
 Otherwise, go read
-[Docker's contributions guidelines](https://github.com/dotcloud/docker/blob/master/CONTRIBUTING.md).
+[Docker's contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
 
 Happy hacking!


### PR DESCRIPTION
Fixes running tests in clean environment.

```
go test ./...
# github.com/docker/libchan
inmem_test.go:9:2: cannot find package "github.com/dotcloud/docker/pkg/testutils" in any of:
    /Users/pnasrat/Library/homebrew/Cellar/go/1.3/libexec/src/pkg/github.com/dotcloud/docker/pkg/testutils (from $GOROOT)
    /Users/pnasrat/go/src/github.com/dotcloud/docker/pkg/testutils (from $GOPATH)
FAIL    github.com/docker/libchan [setup failed]
# github.com/docker/libchan/unix
inmem_test.go:9:2: cannot find package "github.com/dotcloud/docker/pkg/testutils" in any of:
    /Users/pnasrat/Library/homebrew/Cellar/go/1.3/libexec/src/pkg/github.com/dotcloud/docker/pkg/testutils (from $GOROOT)
    /Users/pnasrat/go/src/github.com/dotcloud/docker/pkg/testutils (from $GOPATH)
FAIL    github.com/docker/libchan/unix [setup failed]
# github.com/docker/libchan/utils
inmem_test.go:9:2: cannot find package "github.com/dotcloud/docker/pkg/testutils" in any of:
    /Users/pnasrat/Library/homebrew/Cellar/go/1.3/libexec/src/pkg/github.com/dotcloud/docker/pkg/testutils (from $GOROOT)
    /Users/pnasrat/go/src/github.com/dotcloud/docker/pkg/testutils (from $GOPATH)
FAIL    github.com/docker/libchan/utils [setup failed]
ok      github.com/docker/libchan/data  0.006s
ok      github.com/docker/libchan/http2 0.045s
```
