### PR TITLE
Added jsChan as an alternative implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ for {
 ### Java
 - https://github.com/ndeloof/jchan
 
+### Javascript / Node.js
+- https://github.com/GraftJS/jschan
+
 ## Copyright and license
 
 Code and documentation copyright 2013-2014 Docker, inc. Code released under the Apache 2.0 license.


### PR DESCRIPTION
As jsChan is compatible with https://github.com/docker/libchan/pull/38 and https://github.com/docker/libchan/issues/51 I think It's good to list it in here.

Thanks for the awesome work and all the support!
