### PR TITLE
Update channel passing to use reference ids instead of stream ids

### DIFF
--- a/spdy/session.go
+++ b/spdy/session.go
@@ -328,9 +328,11 @@ func (c *channel) createSubChannel(direction direction) (libchan.Sender, libchan
 		return nil, nil, streamErr
 	}
 	subChannel := &channel{
-		stream:    stream,
-		session:   c.session,
-		direction: direction,
+		referenceID: referenceID,
+		parentID:    c.referenceID,
+		stream:      stream,
+		session:     c.session,
+		direction:   direction,
 	}
 
 	c.session.channelC.L.Lock()


### PR DESCRIPTION
Necessary to achieve compatibility with other clients which are not using stream id directly.  This also fixes the binary encoding of the stream id values to always use 4 bytes for 32bit integer values allowing for easier integration than the default go binary varint encoding.

This changes makes docker/libchan and GraftJS/jschan compatible.

Relevant to #51
