### PR TITLE
[WIP] Simple fork exec plugin

### DIFF
--- a/plugin/example/Makefile
+++ b/plugin/example/Makefile
@@ -1,0 +1,16 @@
+all: build
+
+plugin1:
+	go build plugin1.go
+
+server:
+	go build server.go
+
+clean:
+	rm -f ./plugin1 ./server
+
+build: plugin1 server
+
+run: build
+	./server
+

--- a/plugin/example/plugin1.go
+++ b/plugin/example/plugin1.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/docker/libchan/plugin"
+)
+
+type s1 struct {
+	Key string
+}
+
+func main() {
+	p, err := plugin.InitializePlugin()
+	if err != nil {
+		log.Fatalf("Error initalizing plugin: %s", err)
+	}
+
+	if err := p.ChanOut.Send(&s1{"hello server"}); err != nil {
+		log.Fatalf("Error sending message: %s", err)
+	}
+
+	m := map[string]interface{}{}
+	if err := p.ChanIn.Receive(&m); err != nil {
+		log.Fatalf("Error sending message: %s", err)
+	}
+	log.Printf("Client receive: %#v", m)
+
+	if b, err := ioutil.ReadAll(os.Stdin); err != nil {
+		log.Fatalf("Error reading from stdin: %s", err)
+	} else {
+		log.Printf("Read %q", b)
+	}
+
+	// Close plugin
+}

--- a/plugin/example/server.go
+++ b/plugin/example/server.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"github.com/docker/libchan/plugin"
+)
+
+func main() {
+	config := &plugin.PluginConfiguration{
+		Command: "./plugin1",
+	}
+	p := plugin.NewPluginServer(config)
+	err := p.Start()
+	if err != nil {
+		log.Fatalf("Error starting plugin: %s", err)
+	}
+
+	log.Printf("Receiving")
+
+	var m map[string]interface{}
+	if err := p.ChanOutPipe.Receive(&m); err != nil {
+		log.Fatalf("Error receiving: %s", err)
+	}
+	log.Printf("Received:\n%#v", m)
+
+	m["server_key"] = "val"
+	if err := p.ChanInPipe.Send(m); err != nil {
+		log.Fatalf("Error receiving: %s", err)
+	}
+	log.Printf("Sent:\n%#v", m)
+
+	if err := p.Stop(); err != nil {
+		log.Fatalf("Error stopping plugin: %s", err)
+	}
+
+	log.Printf("Exiting")
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,192 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	"github.com/docker/libchan"
+	"github.com/docker/libchan/spdy"
+)
+
+var (
+	ErrPluginAlreadyStarted = errors.New("plugin already started")
+)
+
+type PluginServer struct {
+	config PluginConfiguration
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+
+	chanInTransport  *spdy.Transport
+	chanOutTransport *spdy.Transport
+
+	ChanInPipe  libchan.Sender
+	ChanOutPipe libchan.Receiver
+
+	l sync.Mutex
+}
+
+type PluginConfiguration struct {
+	Command string
+	Args    []string
+}
+
+func NewPluginServer(config *PluginConfiguration) *PluginServer {
+	plugin := &PluginServer{}
+	plugin.config = *config
+
+	return plugin
+}
+
+func (p *PluginServer) Start() error {
+	p.l.Lock()
+	defer p.l.Unlock()
+
+	if p.cmd != nil {
+		return ErrPluginAlreadyStarted
+	}
+
+	chanInDescriptors, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return err
+	}
+	chanOutDescriptors, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return err
+	}
+
+	chanInChildSocket := os.NewFile(uintptr(chanInDescriptors[0]), "chanInChild")
+	chanInParentSocket := os.NewFile(uintptr(chanInDescriptors[1]), "chanInParent")
+	chanOutChildSocket := os.NewFile(uintptr(chanOutDescriptors[0]), "chanOutChild")
+	chanOutParentSocket := os.NewFile(uintptr(chanOutDescriptors[1]), "chanOutParent")
+	fmt.Printf("%#v %#v", chanInDescriptors, chanOutDescriptors)
+
+	defer chanInChildSocket.Close()
+	defer chanOutChildSocket.Close()
+
+	chanInConn, err := net.FileConn(chanInParentSocket)
+	if err != nil {
+		chanInParentSocket.Close()
+		return err
+	}
+	chanOutConn, err := net.FileConn(chanOutParentSocket)
+	if err != nil {
+		chanOutParentSocket.Close()
+		return err
+	}
+
+	cmd := exec.Command(p.config.Command, p.config.Args...)
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.ExtraFiles = []*os.File{chanInChildSocket, chanOutChildSocket}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		chanOutConn.Close()
+		chanInConn.Close()
+		return err
+	}
+
+	fmt.Println("New receive transport")
+	rt, err := spdy.NewServerTransport(chanInConn)
+	if err != nil {
+		chanOutConn.Close()
+		chanInConn.Close()
+		return err
+	}
+	fmt.Println("New send channel")
+	chanIn, err := rt.NewSendChannel()
+	if err != nil {
+		chanOutConn.Close()
+		chanInConn.Close()
+		return err
+	}
+	fmt.Println("New send transport")
+	st, err := spdy.NewServerTransport(chanOutConn)
+	if err != nil {
+		chanOutConn.Close()
+		chanInConn.Close()
+		return err
+	}
+	fmt.Println("New receive channel")
+	chanOut, err := st.WaitReceiveChannel()
+	if err != nil {
+		chanOutConn.Close()
+		chanInConn.Close()
+		return err
+	}
+	fmt.Println("Done")
+	p.chanInTransport = rt
+	p.chanOutTransport = st
+	p.ChanInPipe = chanIn
+	p.ChanOutPipe = chanOut
+
+	p.cmd = cmd
+	p.stdin = stdin
+
+	return nil
+}
+
+func (p *PluginServer) Stop() error {
+	if p.cmd == nil {
+		return errors.New("Not started")
+	}
+	if p.stdin != nil {
+		if err := p.stdin.Close(); err != nil {
+			return err
+		}
+	}
+	return p.cmd.Wait()
+}
+
+type Plugin struct {
+	ChanIn           libchan.Receiver
+	ChanOut          libchan.Sender
+	chanInTransport  *spdy.Transport
+	chanOutTransport *spdy.Transport
+}
+
+func getTransport(fd uintptr, name string) (*spdy.Transport, error) {
+	f := os.NewFile(fd, name)
+	conn, err := net.FileConn(f)
+	if err != nil {
+		return nil, err
+	}
+	return spdy.NewClientTransport(conn)
+}
+
+func InitializePlugin() (*Plugin, error) {
+	it, err := getTransport(uintptr(3), "chanin")
+	if err != nil {
+		return nil, err
+	}
+	chanIn, err := it.WaitReceiveChannel()
+	if err != nil {
+		return nil, err
+	}
+	ot, err := getTransport(uintptr(4), "chanout")
+	if err != nil {
+		return nil, err
+	}
+	chanOut, err := ot.NewSendChannel()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Plugin{
+		ChanIn:           chanIn,
+		ChanOut:          chanOut,
+		chanInTransport:  it,
+		chanOutTransport: ot,
+	}, nil
+}


### PR DESCRIPTION
Simple implementation for forking and getting a libchan transport.  This is the model used by @BrianBland for the new registry drivers.  The naming is likely completely wrong and this code might belong somewhere else.  It is important though to have a common location and method for libchan forking and subprocess management.  This model will likely be used in the future for running plugins as subprocess as well as a driver model

@erikh any feedback on this will be useful