### PR TITLE
Update spdy Pipe return argument ordering

### DIFF
--- a/spdy/pipe.go
+++ b/spdy/pipe.go
@@ -17,7 +17,7 @@ type pipeReceiver struct {
 }
 
 // Pipe creates a top-level channel pipe using an in memory transport.
-func Pipe() (libchan.Sender, libchan.Receiver, error) {
+func Pipe() (libchan.Receiver, libchan.Sender, error) {
 	c1, c2 := net.Pipe()
 
 	s1, err := newSession(c1, false)
@@ -52,7 +52,7 @@ func Pipe() (libchan.Sender, libchan.Receiver, error) {
 		c2.Close()
 		return nil, nil, receiveErr
 	}
-	return &pipeSender{s1, sender}, &pipeReceiver{s2, receiver}, nil
+	return &pipeReceiver{s2, receiver}, &pipeSender{s1, sender}, nil
 }
 
 func (p *pipeSender) Send(message interface{}) error {

--- a/spdy/pipe_test.go
+++ b/spdy/pipe_test.go
@@ -107,7 +107,7 @@ func SpawnPipeTest(t *testing.T, client PipeSenderRoutine, server PipeReceiverRo
 	endClient := make(chan bool)
 	endServer := make(chan bool)
 
-	sender, receiver, err := Pipe()
+	receiver, sender, err := Pipe()
 	if err != nil {
 		t.Fatalf("Error creating pipe: %s", err)
 	}

--- a/spdy/proxy_test.go
+++ b/spdy/proxy_test.go
@@ -136,8 +136,8 @@ func SpawnProxyTest(t *testing.T, client PipeSenderRoutine, server PipeReceiverR
 	endServer := make(chan bool)
 	endProxy := make(chan bool)
 
-	sender1, receiver1, err := Pipe()
-	sender2, receiver2, err := Pipe()
+	receiver1, sender1, err := Pipe()
+	receiver2, sender2, err := Pipe()
 
 	if err != nil {
 		t.Fatalf("Error creating pipe: %s", err)


### PR DESCRIPTION
Every other method which returns a pipe always returns the inbound side as the first return argument (see libchan.Pipe, io.Pipe). Now spdy.Pipe will follow the same convention.

fixes #74

This is the last change to get in before tagging master as v0.1.0