### PR TITLE
Remove bad local stream reference storage

### DIFF
--- a/spdy/session.go
+++ b/spdy/session.go
@@ -159,10 +159,10 @@ func (s *Transport) createSubStream(parentID uint64) (*stream, error) {
 		session:     s,
 	}
 
-	// TODO: Do not store reference
-	s.streamC.L.Lock()
-	s.streams[referenceID] = newStream
-	s.streamC.L.Unlock()
+	// TODO: hold reference to the newly created stream
+	// for possible cleanup. This stream should not be put
+	// in the streams maps which holds remotely created
+	// streams and will can have reference id conflicts.
 
 	return newStream, nil
 


### PR DESCRIPTION
Libchan reference IDs unlike spdy IDs are only used remotely and increment by 1.
Storing the locally generated id in the streams reference map causes a collision with remotely generated ids.
Since the locally created streams are not referenced by incoming messages, only remote needs to be stored.