### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,34 @@
-Solomon Hykes <solomon@docker.com> (irc: shykes) (github: shykes)
-Derek McGowan <derek@mcgstyle.net> (irc: dmcg) (github: dmcgowan)
-PROTOCOL.md: Solomon Hykes <solomon@docker.com>
+# Libchan maintainers file
+#
+# This file describes who runs the docker/libchan project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"dmcgowan",
+			"shykes",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.dmcgowan]
+	Name = "Derek McGowan"
+	Email = "derek@mcgstyle.net"
+	GitHub = "dmcgowan"
+
+	[people.shykes]
+	Name = "Solomon Hykes"
+	Email = "solomon@docker.com"
+	GitHub = "shykes"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321